### PR TITLE
Fix purge api call

### DIFF
--- a/cf-purge/app.py
+++ b/cf-purge/app.py
@@ -32,7 +32,7 @@ def purge(key):
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_token}",
         },
-        body=json.dumps({"files": [file]}),
+        body=json.dumps({"prefixes": [file]}),
         timeout=timeout,
     )
     print(r.status, r.data, key)


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/6533


## Description

there is no files in the api

![image](https://github.com/descope/lambda-s3-cloudflare-purge/assets/130996527/4b010b13-b8f5-4234-85b0-556963a5b9f7)

it needs to be prefixes

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
